### PR TITLE
Install frontend dependencies in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,11 @@ COPY server.mjs ./
 COPY lib/ ./lib/
 COPY www/ ./www/
 
+# Install frontend dependencies
+WORKDIR /app/www
+RUN npm ci --only=production
+WORKDIR /app
+
 # Create non-root user for security
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S slideshow -u 1001 -G nodejs && \


### PR DESCRIPTION
## Summary
- Fix Docker build to install frontend dependencies (jQuery, underscore, purecss, etc.) in `www/node_modules/`
- Resolves 404 errors for JavaScript assets when running the containerized app

## Test plan
- [ ] Rebuild Docker image: `docker build -t pi_slide_show .`
- [ ] Run container: `docker run -p 3000:3000 -v /path/to/photos:/photos:ro pi_slide_show`
- [ ] Verify http://localhost:3000 loads with no 404 errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)