### PR TITLE
Fix progressive column loss bug in fillRemainingSpace

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,9 @@ npm test                # Unit and performance tests
 npm run test:e2e        # E2E tests (requires: npx playwright install chromium)
 npm run test:all        # All tests
 
+# Run long-running stability tests (optional, ~7 minutes)
+LONG_RUNNING_TEST=1 npm run test:e2e -- --grep "Column Stability"
+
 # Docker build and run
 docker build -t pi_slide_show .
 docker run -p 3000:3000 -v /path/to/photos:/photos:ro pi_slide_show

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ npm run dev
 npm test              # Unit and performance tests
 npm run test:e2e      # E2E tests (requires: npx playwright install chromium)
 npm run test:all      # All tests
+
+# Run long-running stability tests (optional, ~7 minutes)
+LONG_RUNNING_TEST=1 npm run test:e2e -- --grep "Column Stability"
 ```
 
 ## Docker

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,8 @@
 # TODO: Layout Variety Improvements
 
+> **Status: COMPLETE** - This feature has been fully implemented and deployed.
+> This document is preserved as a specification reference.
+
 ## Summary
 
 The current layout algorithm produces repetitive "Landscape, Landscape, Portrait" patterns on both rows due to deterministic left-to-right filling based on container aspect ratio. This improvement adds randomness at multiple levels to create more visually interesting and varied layouts.


### PR DESCRIPTION
## Summary
- Fix bug where `fillRemainingSpace` would give up when it got a landscape for a 1-column slot, causing progressive column loss over multiple swap cycles
- Add long-running column stability E2E tests (skipped by default, run with `LONG_RUNNING_TEST=1`)
- Document the new test option in README and CLAUDE.md

## Changes
- **www/js/main.js**: Fix 1-column filling logic to use portraits or stacked landscapes (matching `build_row` logic)
- **test/e2e/slideshow.spec.mjs**: Add column stability tests that monitor columns over multiple swap cycles
- **README.md / CLAUDE.md**: Add `LONG_RUNNING_TEST` documentation
- **TODO.md**: Add completion status banner

## Test plan
- [x] `npm test` - all unit tests pass
- [x] `npm run test:e2e` - all E2E tests pass
- [ ] `LONG_RUNNING_TEST=1 npm run test:e2e -- --grep "Column Stability"` - stability tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)