### PR TITLE
Add memory and performance optimizations for Raspberry Pi

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   slideshow:
     build: .

--- a/lib/slideshow.mjs
+++ b/lib/slideshow.mjs
@@ -12,12 +12,20 @@ const MAX_DIRECTORY_DEPTH = 20;
 const MAX_DIRECTORY_SEARCH_ATTEMPTS = 10;
 const DIRECTORY_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
+// EXIF orientation cache settings (reduces repeated file reads)
+const EXIF_CACHE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+const EXIF_CACHE_MAX_SIZE = 5000; // Max entries before LRU eviction
+
+// Concurrency limit for EXIF reads (prevents I/O spike on slow storage)
+const EXIF_CONCURRENCY_LIMIT = 4;
+
 export class SlideShow {
   #photoLibrary;
   #webPhotoDir;
   #defaultCount;
   #directoryCache;
   #directoryCacheTimestamp;
+  #exifCache;
 
   constructor(config = {}) {
     this.#photoLibrary = config.photo_library || null;
@@ -25,6 +33,7 @@ export class SlideShow {
     this.#defaultCount = config.default_count || 25;
     this.#directoryCache = null;
     this.#directoryCacheTimestamp = 0;
+    this.#exifCache = new Map(); // filePath → { orientation, timestamp }
   }
 
   get photoLibrary() {
@@ -46,6 +55,14 @@ export class SlideShow {
   invalidateCache() {
     this.#directoryCache = null;
     this.#directoryCacheTimestamp = 0;
+  }
+
+  /**
+   * Invalidate the EXIF orientation cache, forcing re-reads on next request.
+   * Call this if photos have been modified in place or rotated externally.
+   */
+  invalidateExifCache() {
+    this.#exifCache.clear();
   }
 
   /**
@@ -222,17 +239,79 @@ export class SlideShow {
     return shuffled.slice(0, count);
   }
 
+  /**
+   * Evict oldest EXIF cache entries when over max size (LRU-style).
+   */
+  #evictOldestExifEntries() {
+    if (this.#exifCache.size <= EXIF_CACHE_MAX_SIZE) {
+      return;
+    }
+
+    // Remove oldest entries (by timestamp)
+    const entriesToRemove = this.#exifCache.size - EXIF_CACHE_MAX_SIZE + 100; // Remove 100 extra for headroom
+    const sorted = [...this.#exifCache.entries()]
+      .sort((a, b) => a[1].timestamp - b[1].timestamp)
+      .slice(0, entriesToRemove);
+
+    for (const [path] of sorted) {
+      this.#exifCache.delete(path);
+    }
+  }
+
   async extractOrientation(filePath) {
+    const now = Date.now();
+
+    // Check cache first
+    const cached = this.#exifCache.get(filePath);
+    if (cached && (now - cached.timestamp) < EXIF_CACHE_TTL_MS) {
+      return cached.orientation;
+    }
+
+    // Cache miss or expired - read from file
+    let orientation = 1;
     try {
       const orient = await exifr.orientation(filePath);
       // EXIF orientation values: 1, 2, 3, 4, 5, 6, 7, 8
       // Most common: 1 (normal), 3 (180°), 6 (90° CW), 8 (90° CCW)
-      return orient || 1;
+      orientation = orient || 1;
     } catch (err) {
       // Default to normal orientation if extraction fails
       // Don't log - many images legitimately don't have EXIF data
-      return 1;
+      orientation = 1;
     }
+
+    // Cache the result
+    this.#evictOldestExifEntries();
+    this.#exifCache.set(filePath, { orientation, timestamp: now });
+
+    return orientation;
+  }
+
+  /**
+   * Process items with limited concurrency to prevent I/O spikes.
+   * @param {number} concurrency - Maximum concurrent operations
+   * @param {Array} items - Items to process
+   * @param {Function} fn - Async function to apply to each item
+   * @returns {Promise<Array>} - Results in same order as input
+   */
+  async #asyncPool(concurrency, items, fn) {
+    const results = [];
+    const executing = new Set();
+
+    for (const [index, item] of items.entries()) {
+      const promise = Promise.resolve().then(() => fn(item, index));
+      results[index] = promise;
+      executing.add(promise);
+
+      const cleanup = () => executing.delete(promise);
+      promise.then(cleanup, cleanup);
+
+      if (executing.size >= concurrency) {
+        await Promise.race(executing);
+      }
+    }
+
+    return Promise.all(results);
   }
 
   async getRandomAlbum(count = null) {
@@ -257,8 +336,11 @@ export class SlideShow {
 
     const selectedPhotos = this.selectRandomPhotos(images, photoCount);
 
-    const imageData = await Promise.all(
-      selectedPhotos.map(async (filePath) => {
+    // Use concurrency-limited pool instead of Promise.all to prevent I/O spikes
+    const imageData = await this.#asyncPool(
+      EXIF_CONCURRENCY_LIMIT,
+      selectedPhotos,
+      async (filePath) => {
         const orientValue = await this.extractOrientation(filePath);
         const relativePath = relative(library, filePath);
         const webPath = join(this.#webPhotoDir, relativePath);
@@ -267,7 +349,7 @@ export class SlideShow {
           Orientation: orientValue,
           file: webPath
         };
-      })
+      }
     );
 
     return {

--- a/test/unit/slideshow.test.mjs
+++ b/test/unit/slideshow.test.mjs
@@ -291,6 +291,35 @@ describe('SlideShow', () => {
 
       expect(orientation).toBe(1);
     });
+
+    it('should cache orientation and return same value on subsequent calls', async () => {
+      const slideshow = new SlideShow({ photo_library: fixturesDir });
+      const imagePath = join(fixturesDir, 'valid-photos', 'landscape1.jpg');
+
+      // First call - reads from file
+      const orientation1 = await slideshow.extractOrientation(imagePath);
+      // Second call - should return cached value
+      const orientation2 = await slideshow.extractOrientation(imagePath);
+
+      expect(orientation1).toBe(orientation2);
+      expect(orientation1).toBe(1);
+    });
+
+    it('should clear cache when invalidateExifCache is called', async () => {
+      const slideshow = new SlideShow({ photo_library: fixturesDir });
+      const imagePath = join(fixturesDir, 'valid-photos', 'landscape1.jpg');
+
+      // First call - reads from file and caches
+      await slideshow.extractOrientation(imagePath);
+
+      // Invalidate cache
+      slideshow.invalidateExifCache();
+
+      // This call should read from file again (cache was cleared)
+      // We can't directly verify cache state, but we can verify the method works
+      const orientation = await slideshow.extractOrientation(imagePath);
+      expect(orientation).toBe(1);
+    });
   });
 
   describe('getRandomAlbum', () => {


### PR DESCRIPTION
## Summary
- Add EXIF orientation caching with 30-min TTL and LRU eviction (max 5000 entries)
- Add concurrency-limited async pool for EXIF reads (max 4 concurrent)
- Add bounded rate limiter with LRU eviction (max 10,000 IPs)
- Add timer cleanup before page reload to prevent memory leaks
- Add image preload timeout (30s) to prevent hung Image objects
- Fix CSS rule accumulation in resize handler (CSSOM bloat)
- Batch fill photo animations with CSS animation-delay (reduces timer count)

## Test plan
- [x] All 162 unit tests pass
- [x] All 23 E2E tests pass
- [x] Code review completed (`/review-nodejs`)
- [x] Documentation review completed (`/review-docs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)