### PR TITLE
Fix empty photo cells with animation watchdog and recovery system

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Raspberry Pi photo slideshow application that displays random photos from your
 - **Progressive image loading** - Fast initial display with M thumbnails, XL upgrades in background
 - **Seamless album transitions** - Pre-fetches next album in background, fades between albums with no black screen
 - **Image preloading** - Smooth transitions with no dark screens
+- **Automatic recovery system** - Watchdog monitors for stuck/invisible cells and failed image loads, automatically recovers with photo swaps
 - **EXIF orientation support** - Photos display correctly regardless of camera orientation
 - **Synology NAS support** - Uses thumbnail paths for optimized loading
 - **Cache-busting assets** - CSS/JS versioned on server restart for remote displays

--- a/www/js/config.mjs
+++ b/www/js/config.mjs
@@ -55,6 +55,13 @@ export const PREFETCH_MEMORY_THRESHOLD_MB = 100;  // Skip prefetch if available 
 export const FORCE_RELOAD_INTERVAL = 8;           // Force full page reload every N transitions (memory hygiene)
 export const MIN_PHOTOS_FOR_TRANSITION = 15;      // Minimum photos required for seamless transition (fall back to reload if less)
 
+// Watchdog and recovery configuration
+// Monitors live cells for stuck animations and failed image loads
+export const WATCHDOG_INTERVAL_MS = 3000;         // Watchdog scan frequency (ms)
+export const WATCHDOG_STUCK_GRACE_PERIOD_MS = 1000;  // Grace period before marking cell as stuck (ms)
+export const WATCHDOG_LOAD_ERROR_DELAY_MS = 500;     // Delay before recovering failed image load (ms)
+export const WATCHDOG_SWAP_DEFER_MS = 100;          // Deferral time for swap queueing to avoid race conditions (ms)
+
 // Make available as global for browser usage (non-module scripts)
 if (typeof window !== 'undefined') {
     window.SlideshowConfig = {
@@ -87,6 +94,10 @@ if (typeof window !== 'undefined') {
         ALBUM_TRANSITION_FADE_DURATION,
         PREFETCH_MEMORY_THRESHOLD_MB,
         FORCE_RELOAD_INTERVAL,
-        MIN_PHOTOS_FOR_TRANSITION
+        MIN_PHOTOS_FOR_TRANSITION,
+        WATCHDOG_INTERVAL_MS,
+        WATCHDOG_STUCK_GRACE_PERIOD_MS,
+        WATCHDOG_LOAD_ERROR_DELAY_MS,
+        WATCHDOG_SWAP_DEFER_MS
     };
 }


### PR DESCRIPTION
## Summary

Fixes the empty photo cell issue that appeared after photo swaps by implementing a comprehensive animation watchdog and recovery system with security hardening.

## Changes

### Core Fixes
1. **Fill photo opacity cleanup** - Clear inline opacity after animation to prevent snapping invisible
2. **Image load error recovery** - Detect failed image loads and swap photos
3. **Animation watchdog** - Monitor cells every 3 seconds for stuck/invisible state
4. **Orphaned DOM cleanup** - Return unused elements to photo_store

### Security & Performance
- ✅ Fixed memory leak: Watchdog interval cleanup on page transitions
- ✅ Fixed race condition: Deferred recovery swaps to avoid concurrent animations
- ✅ Fixed handler leak: Use `.one()` to prevent multiple handlers
- ✅ Improved robustness: Added null checks and validation
- ✅ Production logging: Use debugLog instead of console output

### Documentation
- **README.md**: Added watchdog feature to features list
- **ARCHITECTURE.md**: New "Recovery and Resilience" section (5.1)
- **docs/visual-algorithm.md**: Comprehensive "Watchdog and Recovery System" section with 50+ lines
- **www/js/config.mjs**: Exported 4 configurable watchdog timing constants
- **www/js/main.js**: Replaced hardcoded values with config constants

## Test Plan

- [x] All 470 unit tests pass
- [x] Docker build and container startup successful
- [x] API endpoints responding correctly (/album/25)
- [x] Code review completed (security & performance)
- [x] Documentation review completed (consistency & completeness)

## Verification Steps

To test the fix:
1. \`docker compose up -d --build\`
2. Watch the slideshow for 5+ minutes
3. Open DevTools console to see watchdog activity (set \`DEBUG_PROGRESSIVE_LOADING: true\` in config)
4. Verify no empty cells appear after swaps
5. Force image load errors to verify recovery mechanism works

## Configuration

Watchdog timing is fully configurable via \`www/js/config.mjs\`:
- \`WATCHDOG_INTERVAL_MS\` - Scan frequency (default: 3000ms)
- \`WATCHDOG_STUCK_GRACE_PERIOD_MS\` - Grace before marking stuck (default: 1000ms)
- \`WATCHDOG_LOAD_ERROR_DELAY_MS\` - Delay before recovery (default: 500ms)
- \`WATCHDOG_SWAP_DEFER_MS\` - Swap deferral (default: 100ms)

Adjust these for different devices or performance requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)