### PR TITLE
Fix persistent blank photo cells with root cause fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,10 @@ Shared constants for animation timing, layout probabilities, and thresholds:
 | `PREFETCH_MEMORY_THRESHOLD_MB` | `100` | Skip prefetch if available memory below threshold (MB) |
 | `FORCE_RELOAD_INTERVAL` | `8` | Force full page reload every N transitions (memory hygiene) |
 | `MIN_PHOTOS_FOR_TRANSITION` | `15` | Minimum photos required for seamless transition |
+| `WATCHDOG_INTERVAL_MS` | `3000` | Watchdog scan frequency (ms) |
+| `WATCHDOG_STUCK_GRACE_PERIOD_MS` | `1000` | Grace period before marking cell as stuck (ms) |
+| `WATCHDOG_LOAD_ERROR_DELAY_MS` | `500` | Delay before recovering failed image loads (ms) |
+| `WATCHDOG_SWAP_DEFER_MS` | `100` | Deferral time for swap queueing (ms) |
 
 Additional constants available in `config.mjs`:
 - `PANORAMA_USE_PROBABILITY`, `PANORAMA_STEAL_PROBABILITY`, `PANORAMA_POSITION_LEFT_PROBABILITY` - Panorama placement behavior

--- a/www/js/photo-store.mjs
+++ b/www/js/photo-store.mjs
@@ -508,7 +508,6 @@ export function fillRemainingSpace($, build_div, row, $newPhoto, remainingColumn
                 if (stackedDiv) {
                     stackedDiv.data('display_time', Date.now());
                     stackedDiv.data('columns', 1);
-                    stackedDiv.css('opacity', '0');
                     newPhotos.push(stackedDiv);
                     remainingColumns -= 1;
                     continue; // Skip the normal photo handling below
@@ -534,8 +533,6 @@ export function fillRemainingSpace($, build_div, row, $newPhoto, remainingColumn
         div = build_div(photo, width, totalColumnsInGrid);
         div.data('display_time', Date.now());
         div.data('columns', width);
-        div.css('opacity', '0'); // Start invisible for fade-in animation
-
         newPhotos.push(div);
         remainingColumns -= width;
     }


### PR DESCRIPTION
## Summary

- **Fix cross-row timer cancellation**: `animateSwap()` was clearing ALL `pendingAnimationTimers` globally, canceling in-flight timers from the other row and breaking promise chains that make fill photos visible
- **Remove fragile inline `opacity: 0`**: Fill photos relied on a cleanup timer at the end of a long promise chain to clear inline opacity; `visibility: hidden` + slide-in keyframe `fill-mode: both` already handles the visibility lifecycle
- **Watchdog strips animation classes before recovery**: CSS `animation-fill-mode: forwards` holds `opacity: 0; transform: scale(0)`, overriding inline styles — watchdog now removes classes, inline styles, and custom properties
- **Watchdog detects cells with missing/broken images**: New `empty-since` tracking catches cells with no `<img>` or empty `src` that the existing checks missed

## Test plan

- [x] `npm test` — 470 unit tests pass
- [x] `npm run test:e2e` — 57 E2E tests pass
- [x] `/review-nodejs` — no critical or important issues
- [x] `/review-docs` — all identified doc issues addressed in this PR
- [ ] Manual: run slideshow for 15+ minutes, verify no blank cells appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)