### PR TITLE
Refactor build_row to append photos incrementally; bump DEFAULT_COUNT to 35

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ npm run dev          # Watch for SCSS changes
   - `PHOTO_LIBRARY` - Source directory path (default: `/mnt/photo`)
   - `PORT` - Server port (default: `3000`)
   - `WEB_PHOTO_DIR` - URL path prefix for photos
-  - `DEFAULT_COUNT` - Number of random photos per batch (default: `25`)
+  - `DEFAULT_COUNT` - Number of random photos per batch (default: `35`)
   - `LOG_LEVEL` - Logging verbosity: error, warn, info, debug (default: `info`, Docker: `error`)
   - `RATE_LIMIT_MAX_REQUESTS` - Max requests per minute per IP (default: `100`, localhost gets 50x multiplier)
 
@@ -109,7 +109,7 @@ npm run dev          # Watch for SCSS changes
 
 - `www/index.html` - Single-page app using Pure CSS grid, jQuery, and Underscore.js
 - `www/js/config.mjs` - **Shared configuration constants** (used by both frontend and tests)
-- `www/js/main.js` - Fetches `/album/25`, preloads images, builds responsive grid with slide animations (bounce effect)
+- `www/js/main.js` - Fetches `/album/35`, preloads images, builds responsive grid with slide animations (bounce effect)
 - `www/js/photo-store.mjs` - **Photo selection and layout module** with functions for random photo selection, orientation matching, panorama detection, stacked landscape creation, and space management for the grid layout
 - `www/js/prefetch.mjs` - **Album pre-fetch module** with functions for pre-fetching next album, memory checks, and AbortController management
 - `www/js/utils.mjs` - **Utility functions** for thumbnail URL construction, image preloading, and progressive loading helpers
@@ -236,7 +236,7 @@ Use for architecture decisions and reviews:
 Two distinct testing approaches for different concerns:
 
 1. **Album Lookup Tests** (`test/perf/album-lookup.perf.mjs`)
-   - Tests `/album/25` API endpoint performance
+   - Tests `/album/35` API endpoint performance
    - Uses random photos (tests real-world usage)
    - Measures filesystem crawling and JSON generation speed
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Configuration can be set via `generate_slideshow.yml` or environment variables:
 | Setting | Environment Variable | Default | Description |
 |---------|---------------------|---------|-------------|
 | `photo_library` | `PHOTO_LIBRARY` | `/mnt/photo` | Path to photo directory |
-| `default_count` | `DEFAULT_COUNT` | `25` | Photos per page load |
+| `default_count` | `DEFAULT_COUNT` | `35` | Photos per page load |
 | `web_photo_dir` | `WEB_PHOTO_DIR` | `photos` | URL prefix for photos |
 | - | `PORT` | `3000` | Server port |
 | - | `LOG_LEVEL` | `info` (Docker: `error`) | Logging verbosity (error/warn/info/debug) |
@@ -155,7 +155,7 @@ There are two types of performance tests, each designed for a specific purpose:
 
 **1. Album Lookup Performance** (`test/perf/album-lookup.perf.mjs`)
 
-Tests the `/album/25` API endpoint performance (filesystem crawling and random selection):
+Tests the `/album/35` API endpoint performance (filesystem crawling and random selection):
 - Measures response time across multiple iterations
 - Calculates min, max, average, and p95 statistics
 - Uses random photos by design (tests real-world usage)

--- a/TODO.md
+++ b/TODO.md
@@ -26,20 +26,31 @@ Address gaps between documented architecture and implementation, plus code simpl
 ## Known Issues
 
 ### Persistent Blank Photo Cells
-**Status:** FIXED (2026-02-19)
+**Status:** FIXED (2026-04-08)
 **Priority:** HIGH
-**Description:** Blank/empty photo cells appear in the slideshow grid and sometimes persist indefinitely. A previous fix (commit f92062d) added a watchdog and opacity cleanup, but the bug persisted because the watchdog couldn't override CSS animation states, and the root cause (global timer clearing) was never addressed.
+**Description:** Blank/empty photo cells appear in the slideshow grid and sometimes persist indefinitely. A previous fix (commit f92062d) added a watchdog and opacity cleanup, but the bug persisted because the watchdog couldn't override CSS animation states, and the root cause (global timer clearing) was never addressed. A fourth root cause was identified on 2026-04-08 via live Chrome debugging: during album transitions, the clone fallback queried DOM rows that were just emptied.
 
 **Root Causes Identified:**
 1. `pendingAnimationTimers` was global — `animateSwap()` cleared ALL pending timers at the start, canceling in-flight timers from the other row and breaking promise chains
 2. Fill photos used fragile inline `opacity: 0` — only cleared by a cleanup timer at the end of a long promise chain; if any link broke, opacity stayed at 0 forever
 3. Watchdog couldn't override CSS animations — shrink animation classes use `animation-fill-mode: forwards`, which holds `opacity: 0; transform: scale(0)` and overrides inline styles
+4. During album transitions, `build_row()` collects photos into a local `photoDivs[]` array and appends them to the DOM only after the loop. When the photo store was exhausted mid-loop, the `clonePhotoFromPage` fallback queried `#top_row .img_box, #bottom_row .img_box` — both empty because the transition had just cleared them — and returned null, skipping the slot and producing an empty cell.
 
 **Fixes Applied:**
 - [x] Remove global `pendingAnimationTimers` clearing in `animateSwap()` (`www/js/main.js`)
 - [x] Remove inline `opacity: 0` from fill photos — `visibility: hidden` and slide-in keyframes handle visibility lifecycle (`www/js/photo-store.mjs`, `www/js/main.js`)
 - [x] Watchdog strips animation classes before recovery — removes CSS classes, inline styles, and custom properties (`www/js/main.js`)
 - [x] Watchdog detects cells with missing/broken images — new `empty-since` tracking for cells with no `<img>` or empty `src` (`www/js/main.js`)
+- [x] Clone fallback accepts in-progress photoDivs — added optional `extraPhotos` parameter to `clonePhotoFromPage` and `selectPhotoForContainer`, plumbed `photoDivs` through 6 fallback call sites in `build_row()` (`www/js/photo-store.mjs`, `www/js/main.js`)
+
+**Follow-ups (architect review 2026-04-08):**
+- [x] Refactored `build_row()` to append photos to the DOM incrementally via an `insertPhoto()` helper that handles ltr/rtl and panorama-on-left placement inline; removed `photoDivs[]` staging and the `extraPhotos` parameter from `clonePhotoFromPage`/`selectPhotoForContainer`. DOM is now the single source of truth.
+- [x] Bumped `DEFAULT_COUNT` from 25 → 35 (`server.mjs`, `generate_slideshow.yml`, frontend fetches in `main.js`, perf tests, CLAUDE.md, docs).
+- [x] Audit complete 2026-04-08: panorama-steal recursive `build_row` path is already safe. (a) The `!skipAnimation` guard (main.js ~723) prevents it during album transitions — the only scenario the original bug exposed. (b) During normal operation, the recursive call fires inside the parent row's fade-in callback, after parent photos have been appended to the DOM, so `clonePhotoFromPage` finds them via its existing selector. No code change required.
+
+**Deferred test follow-ups (QA review 2026-04-09):**
+- [ ] Add a `build_row`-level integration test (jsdom harness) that exercises `build_row()` with a store containing fewer photos than `columns` and asserts (a) no empty cells, (b) fallback clones come from earlier-inserted divs in the same row. Locks in the incremental-append invariant at the integration level.
+- [ ] Add a deterministic E2E test for `rtl` + panorama-on-left ordering: requires a test hook to force `fillDirection='rtl'` and `panoramaOnLeft=true`, then asserts panorama stays leftmost, no empty cells, and column sum equals grid width. Currently only hit probabilistically by the existing E2E suite.
 
 ---
 

--- a/docs/visual-algorithm.md
+++ b/docs/visual-algorithm.md
@@ -391,7 +391,7 @@ While individual photos swap every 10 seconds within the current album, the enti
 **New Behavior (Phase 2 implemented):** Seamless fade-out/fade-in transition with pre-fetching:
 
 1. **Pre-fetch Phase** (triggered 1 minute before transition):
-   - Fetch next album data from `/album/25` endpoint
+   - Fetch next album data from `/album/35` endpoint
    - Preload images in background using initial quality (M thumbnails)
    - Create img_box elements (not yet in DOM)
    - Memory guard: skip prefetch if available heap < 100MB

--- a/server.mjs
+++ b/server.mjs
@@ -123,7 +123,7 @@ async function loadConfig() {
   const config = {
     photo_library: process.env.PHOTO_LIBRARY || fileConfig.photo_library,
     web_photo_dir: process.env.WEB_PHOTO_DIR || fileConfig.web_photo_dir || 'photos',
-    default_count: parseInt(process.env.DEFAULT_COUNT, 10) || fileConfig.default_count || 25,
+    default_count: parseInt(process.env.DEFAULT_COUNT, 10) || fileConfig.default_count || 35,
     port: parseInt(process.env.PORT, 10) || DEFAULT_PORT
   };
 

--- a/test/e2e/slideshow.spec.mjs
+++ b/test/e2e/slideshow.spec.mjs
@@ -139,7 +139,7 @@ test.describe('Slideshow E2E Tests', () => {
   });
 
   test('album endpoint returns valid JSON structure', async ({ page }) => {
-    const response = await page.request.get('/album/25');
+    const response = await page.request.get('/album/35');
 
     expect(response.ok()).toBe(true);
     expect(response.headers()['content-type']).toContain('application/json');

--- a/test/perf/album-lookup.perf.mjs
+++ b/test/perf/album-lookup.perf.mjs
@@ -1,7 +1,7 @@
 /**
  * Album Lookup Performance Test
  *
- * Tests the /album/25 API endpoint performance (filesystem crawling, random selection).
+ * Tests the /album/35 API endpoint performance (filesystem crawling, random selection).
  * This test uses random photos (as in real-world usage) to measure API response times.
  *
  * Metrics tracked:
@@ -175,7 +175,7 @@ test.describe('Album Lookup Performance Tests', () => {
       const start = Date.now();
 
       try {
-        const response = await page.request.get(`${DOCKER_URL}/album/25`, {
+        const response = await page.request.get(`${DOCKER_URL}/album/35`, {
           timeout: TIMEOUTS.API_CALL
         });
         const responseTime = Date.now() - start;
@@ -274,7 +274,7 @@ test.describe('Album Lookup Performance Tests', () => {
   test('Album API Response Structure', async ({ page }) => {
     test.setTimeout(TIMEOUTS.API_CALL + 10000);
 
-    const response = await page.request.get(`${DOCKER_URL}/album/25`, {
+    const response = await page.request.get(`${DOCKER_URL}/album/35`, {
       timeout: TIMEOUTS.API_CALL
     });
 
@@ -311,7 +311,7 @@ test.describe('Album Lookup Performance Tests', () => {
     for (let i = 0; i < 3; i++) {
       if (i > 0) await page.waitForTimeout(CONFIG.DELAY_BETWEEN_CALLS);
 
-      const response = await page.request.get(`${DOCKER_URL}/album/25`, {
+      const response = await page.request.get(`${DOCKER_URL}/album/35`, {
         timeout: TIMEOUTS.API_CALL
       });
 

--- a/test/perf/fixtures-utils.mjs
+++ b/test/perf/fixtures-utils.mjs
@@ -10,7 +10,7 @@
  * Falls back to regular page loading if fixture data is not provided.
  *
  * This overrides jQuery.getJSON to return the fixture data instead of
- * fetching from /album/25, enabling reproducible performance tests.
+ * fetching from the live /album/:count endpoint, enabling reproducible performance tests.
  *
  * @param {Page} page - Playwright page object
  * @param {string} serverUrl - Base URL of the server
@@ -22,7 +22,7 @@ export async function loadPageWithFixture(page, serverUrl, fixtureData = null) {
   await page.goto(serverUrl, { waitUntil: 'domcontentloaded' });
 
   if (fixtureData) {
-    // Inject test mode that uses fixture data instead of fetching /album/25
+    // Inject test mode that uses fixture data instead of fetching from /album/:count
     await page.evaluate((data) => {
       // Store fixture for test verification
       window.__testFixtureData = data;

--- a/test/perf/phase-timing.perf.mjs
+++ b/test/perf/phase-timing.perf.mjs
@@ -339,6 +339,7 @@ test.describe('Phase Timing Performance Tests', () => {
       if (i > 0) await page.waitForTimeout(500);
 
       const start = Date.now();
+      // Held at /album/25 (not the new 35 default) so latency history stays comparable across runs.
       const response = await page.request.get(`${DOCKER_URL}/album/25`, {
         timeout: TIMEOUTS.PHASE_ONE
       });

--- a/test/unit/photo-store.test.mjs
+++ b/test/unit/photo-store.test.mjs
@@ -508,6 +508,40 @@ describe('Photo Store Module', () => {
             const result = PhotoStore.clonePhotoFromPage(mock$, 'landscape');
             expect(result).toBeTruthy();
         });
+
+        it('should find a photo appended earlier in the same build_row call', () => {
+            // Regression test for the incremental-append refactor: build_row() now
+            // appends each photo to #top_row immediately, so when a later iteration
+            // exhausts the photo store, clonePhotoFromPage must be able to find the
+            // earlier-appended siblings via the existing #top_row/#bottom_row selector.
+            // This locks in the load-bearing invariant the refactor introduced.
+            const earlierAppended = { id: 'earlier-appended' };
+            const $earlierAppended = new MockJQuery('.img_box', [earlierAppended]);
+            $earlierAppended.data({
+                height: 1920,
+                width: 1080,
+                aspect_ratio: 0.5625,
+                orientation: 'portrait',
+                panorama: false
+            });
+
+            mock$ = function(selector) {
+                if (selector === '#top_row .img_box, #bottom_row .img_box') {
+                    // Simulates: photo store empty, but an earlier iteration of the
+                    // same build_row() call already appended one photo to #top_row.
+                    const $allPhotos = new MockJQuery(selector, [earlierAppended]);
+                    $allPhotos.random = () => $earlierAppended;
+                    return $allPhotos;
+                }
+                return new MockJQuery(selector, []);
+            };
+
+            const result = PhotoStore.clonePhotoFromPage(mock$, 'portrait');
+            expect(result).toBeTruthy();
+            expect(result).not.toBeNull();
+            expect(result.data('orientation')).toBe('portrait');
+            expect(result.data('aspect_ratio')).toBe(0.5625);
+        });
     });
 
     describe('selectPhotoForContainer', () => {

--- a/www/js/main.js
+++ b/www/js/main.js
@@ -793,8 +793,22 @@
             // Get random fill direction (ltr or rtl)
             var fillDirection = getRandomFillDirection();
 
-            // Build photos into array first, then append based on fill direction
-            var photoDivs = [];
+            // Insert a main-loop photo div at the correct position based on fill direction.
+            // Photos are appended to the DOM incrementally so clonePhotoFromPage() can find
+            // them as a fallback source within the same build_row() call.
+            var insertPhoto = function(div) {
+                if (fillDirection === 'ltr') {
+                    row.append(div);
+                } else if (panoramaContainer && panoramaOnLeft) {
+                    // rtl with left-pano: insert right after pano so previous photos slide right
+                    panoramaContainer.after(div);
+                } else {
+                    // rtl without left-pano: prepend to row
+                    row.prepend(div);
+                }
+                used_columns += div.data('columns');
+            };
+
             var columnsToFill = panoramaContainer ? (columns - panoramaColumns) : columns;
 
             // Count available photos for pattern generation
@@ -830,7 +844,7 @@
                     photo = photo_store.find('#landscape div.img_box').random().detach();
                     if (!photo || photo.length === 0) {
                         // Fallback: try any photo with selectPhotoForContainer (includes clone fallback)
-                        photo = photoStore.selectPhotoForContainer($, containerAspectRatio);
+                        photo = photoStore.selectPhotoForContainer($, containerAspectRatio, false);
                         if (!photo) {
                             // Ultimate fallback: clone a landscape from page
                             photo = photoStore.clonePhotoFromPage($, 'landscape');
@@ -864,7 +878,7 @@
                                 div = build_div(photo, width, columns);
                             } else {
                                 // Fallback: try any photo (includes clone fallback)
-                                photo = photoStore.selectPhotoForContainer($, containerAspectRatio);
+                                photo = photoStore.selectPhotoForContainer($, containerAspectRatio, false);
                                 if (!photo) {
                                     // Ultimate fallback: clone from page
                                     photo = photoStore.clonePhotoFromPage($, 'portrait');
@@ -879,7 +893,7 @@
                         div = build_div(photo, width, columns);
                     } else {
                         // Fallback: try any available photo (includes clone fallback)
-                        photo = photoStore.selectPhotoForContainer($, containerAspectRatio);
+                        photo = photoStore.selectPhotoForContainer($, containerAspectRatio, false);
                         if (!photo) {
                             // Ultimate fallback: clone a portrait from page
                             photo = photoStore.clonePhotoFromPage($, 'portrait');
@@ -891,21 +905,8 @@
 
                 div.data('display_time', Date.now());
                 div.data('columns', width);
-                photoDivs.push(div);
+                insertPhoto(div);
             }
-
-            // Reverse array if fill direction is right-to-left
-            if (fillDirection === 'rtl') {
-                photoDivs.reverse();
-            }
-
-            // Append photos in the determined order
-            // Panorama on left was already appended, so regular photos come after
-            // Panorama on right will be appended after the loop
-            photoDivs.forEach(function(div) {
-                row.append(div);
-                used_columns += div.data('columns');
-            });
 
             // If panorama exists and goes on right, append it last
             if (panoramaContainer && !panoramaOnLeft) {
@@ -1057,7 +1058,7 @@
 
         debugLog('Prefetch: Starting album pre-fetch');
 
-        fetch('/album/25?xtime=' + Date.now(), { signal: signal })
+        fetch('/album/35?xtime=' + Date.now(), { signal: signal })
             .then(function(response) {
                 if (!response.ok) {
                     throw new Error('Album fetch failed: ' + response.status);
@@ -1733,7 +1734,7 @@
 
         var photo_store = $('#photo_store');
 
-        $.getJSON("/album/25?xtime="+_.now())
+        $.getJSON("/album/35?xtime="+_.now())
         .fail(function(jqXHR, textStatus, errorThrown) {
             console.error('Failed to fetch album:', textStatus, errorThrown);
             _.delay(stage_photos, 5000);

--- a/www/js/photo-store.mjs
+++ b/www/js/photo-store.mjs
@@ -81,6 +81,7 @@ export function getAdjacentPhoto($photo, direction) {
  */
 export function clonePhotoFromPage($, preferOrientation) {
     var $allPhotos = $('#top_row .img_box, #bottom_row .img_box');
+
     if ($allPhotos.length === 0) {
         return null;
     }


### PR DESCRIPTION
## Summary
- Refactors `build_row()` in `www/js/main.js` to append photos to the DOM incrementally via a new `insertPhoto()` helper, eliminating the `photoDivs[]` staging array. The DOM is now the single source of truth, which lets `clonePhotoFromPage()` find earlier siblings as a fallback source within the same `build_row()` call — removing the need for the leaky `extraPhotos` parameter previously threaded through `photo-store.mjs`.
- Bumps `DEFAULT_COUNT` from 25 to 35 as defense-in-depth against photo store exhaustion (`server.mjs`, `generate_slideshow.yml`, frontend fetches, perf tests, docs).
- Adds a regression test that locks in the incremental-append invariant — `clonePhotoFromPage` must find a photo appended to `#top_row` by an earlier iteration of the same `build_row()` call.
- Documents the panorama-steal recursive `build_row` audit (already safe, no code change needed) and the doc/test inconsistencies caught by review agents.

## Background
This is the architect-review follow-up to neybar/pi_slide_show#23, which patched the empty-cell bug by threading `extraPhotos` through the clone fallback. That fix worked but split state between a local array and the DOM. This PR removes that leaky abstraction and leaves the code simpler than it started.

## Test plan
- [x] `npm test` — 471 unit tests pass (was 470; net +1 from removing 2 obsolete `extraPhotos` tests and adding 1 regression test)
- [ ] `npm run test:smoke` against a running server
- [ ] `npm run test:e2e` full suite
- [ ] Manual verification on the dev Pi: watch through at least one album transition, confirm no empty cells, confirm panorama placement still works on both sides
- [ ] Verify ltr/rtl layout variety across reloads

## Deferred follow-ups (tracked in `TODO.md`)
- `build_row`-level integration test with a jsdom harness (locks in the invariant at the integration level)
- Deterministic E2E test for `rtl` + panorama-on-left ordering (currently only hit probabilistically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)